### PR TITLE
chore: scaffold api skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+PORT=3000
+DATABASE_URL=postgres://user:password@localhost:5432/hr_platform

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# HR Management Platform Skeleton
+
+This repository contains a minimal Node.js/Express skeleton for a Human Resources management platform. It exposes placeholder endpoints for configuration and employees and provides seed and test scripts.
+
+## Scripts
+
+- `npm run dev` – start development server
+- `npm start` – start server
+- `npm run build` – placeholder build step
+- `npm run migrate` – placeholder migration step
+- `npm run seed` – run sample seed script
+- `npm test` – run placeholder tests
+
+## Environment
+
+Copy `.env.example` to `.env` and adjust variables.
+
+## Endpoints
+
+- `GET /health` – basic health check
+- `GET /config` – fetch current configuration
+- `PUT /config` – update configuration in memory
+- `GET /employees` – list employees in memory
+- `POST /employees` – create a new employee
+
+This skeleton is intended as a starting point for the full platform described in the specification.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    command: npm run dev
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    volumes:
+      - ./:/app
+    working_dir: /app
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: hr_platform
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hr-platform-skeleton",
+  "version": "0.1.0",
+  "main": "src/index.js",
+  "license": "MIT",
+  "scripts": {
+    "dev": "node src/index.js",
+    "build": "echo 'build step'",
+    "start": "node src/index.js",
+    "migrate": "echo 'migrate step'",
+    "seed": "node scripts/seed.js",
+    "test": "node -e \"console.log('no tests yet')\""
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "dotenv": "^16.4.5"
+  }
+}

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,1 @@
+console.log('Seeding placeholder data...');

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+app.use(express.json());
+
+// in-memory config object
+let config = {
+  branding: { name: 'Portal Talento', logoUrl: '', primary: '#0ea5e9' },
+  timezone: 'America/Santo_Domingo'
+};
+
+// in-memory employees
+let employees = [];
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.get('/config', (req, res) => {
+  res.json(config);
+});
+
+app.put('/config', (req, res) => {
+  config = { ...config, ...req.body };
+  res.json(config);
+});
+
+app.get('/employees', (req, res) => {
+  res.json(employees);
+});
+
+app.post('/employees', (req, res) => {
+  const employee = { id: employees.length + 1, ...req.body };
+  employees.push(employee);
+  res.status(201).json(employee);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/templates/employees.csv
+++ b/templates/employees.csv
@@ -1,0 +1,2 @@
+nombre,cedula,fechaIngreso,fechaNacimiento,email,telefono
+Juan Perez,001-0000000-1,01/01/2022,01/01/1990,juan@example.com,8095551234


### PR DESCRIPTION
## Summary
- add express-based skeleton API with config and employee endpoints
- provide environment template, docker-compose, and CSV import sample
- document available scripts and endpoints

## Testing
- `npm test`
- `npm run seed`


------
https://chatgpt.com/codex/tasks/task_e_689ceaebfa188325b32609616a7906f1